### PR TITLE
🕵 support Alpine like iSH in IpadOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ This shell include
 
 ## Support Linux Distribution
 
-Now: support **Ubuntu** + **CentOS** + **Arch** + **Windows(a liitle)** + **MacOS**(I can't find a test machine, hhh, maybe have some bugs.)
+Now: support **Ubuntu** + **CentOS** + **Arch** + + **Alpine**(part of) + **WSL** + **MacOS**(I can't find a test machine, hhh, maybe have some bugs.)
 
 - Test in docker & host version, in AiliYun, TencentCloud and huaweicloud
 - Support amb64 & i386.
-- Support docker version for Ubuntu, CentOS, Ubuntu/32bit
+- Support docker version for Ubuntu, CentOS, Ubuntu/32bit, Alpine(including [iSH](https://github.com/ish-app/ish) in IpadOS)
 - Support WSL, Git Bash Windows
 
 ## Quick Start


### PR DESCRIPTION
To support Linux distributions Alpine which base on musl and BusyBox.
And Alpine can be used in IOS or IpadOS by [iSH](https://github.com/ish-app/ish) app.

Due to iSH is base on musl-linux-i386. 
We limit some features in Alpine.